### PR TITLE
feature: allows user to specify default font theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "type": "module",
   "main": "./dist/react-native-portable-text.es.js",
   "module": "./dist/react-native-portable-text.es.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],

--- a/src/components/block.tsx
+++ b/src/components/block.tsx
@@ -3,7 +3,7 @@ import {View, Text} from 'react-native'
 import type {PortableTextComponent} from '@portabletext/react'
 import type {PortableTextBlock, PortableTextBlockStyle} from '@portabletext/types'
 
-import {blockStyles, textStyles} from './styles'
+import {PortableTextTheme, blockStyles, getTextStylesWithTheme, textStyles} from './styles'
 
 type BlockStyleName = keyof typeof blockStyles
 
@@ -18,6 +18,24 @@ export const DefaultBlock: PortableTextComponent<PortableTextBlock> = ({children
   )
 }
 
+export const getDefaultBlockWithTheme = (
+  theme: PortableTextTheme,
+): PortableTextComponent<PortableTextBlock> => {
+  const textStylesWithTheme = getTextStylesWithTheme(theme)
+
+  const DefaultBlockWithTheme: PortableTextComponent<PortableTextBlock> = ({children, value}) => {
+    const style = (value.style || 'normal') as BlockStyleName
+
+    return (
+      <View style={blockStyles[style]}>
+        <Text style={textStylesWithTheme[style]}>{children}</Text>
+      </View>
+    )
+  }
+
+  return DefaultBlockWithTheme
+}
+
 export const defaultBlockStyles: Record<
   PortableTextBlockStyle,
   PortableTextComponent<PortableTextBlock> | undefined
@@ -30,4 +48,20 @@ export const defaultBlockStyles: Record<
   h4: DefaultBlock,
   h5: DefaultBlock,
   h6: DefaultBlock,
+}
+
+export const getDefaultBlockStylesWithTheme = (
+  theme: PortableTextTheme,
+): Record<PortableTextBlockStyle, PortableTextComponent<PortableTextBlock> | undefined> => {
+  const defaultBlockWithTheme = getDefaultBlockWithTheme(theme)
+  return {
+    normal: defaultBlockWithTheme,
+    blockquote: defaultBlockWithTheme,
+    h1: defaultBlockWithTheme,
+    h2: defaultBlockWithTheme,
+    h3: defaultBlockWithTheme,
+    h4: defaultBlockWithTheme,
+    h5: defaultBlockWithTheme,
+    h6: defaultBlockWithTheme,
+  }
 }

--- a/src/components/defaults.tsx
+++ b/src/components/defaults.tsx
@@ -3,8 +3,8 @@ import {Text} from 'react-native'
 import type {PortableTextReactComponents} from '@portabletext/react'
 
 import {defaultMarks} from './marks'
-import {defaultBlockStyles} from './block'
-import {DefaultList, defaultListItems} from './list'
+import {defaultBlockStyles, getDefaultBlockStylesWithTheme} from './block'
+import {DefaultList, defaultListItems, getDefaultListItemsWithTheme} from './list'
 import {
   DefaultUnknownType,
   DefaultUnknownMark,
@@ -12,6 +12,7 @@ import {
   DefaultUnknownListItem,
   DefaultUnknownBlockStyle,
 } from './unknown'
+import {PortableTextTheme} from './styles'
 
 export const DefaultHardBreak = () => <Text>{'\n'}</Text>
 
@@ -29,4 +30,24 @@ export const defaultComponents: PortableTextReactComponents = {
   unknownList: DefaultUnknownList,
   unknownListItem: DefaultUnknownListItem,
   unknownBlockStyle: DefaultUnknownBlockStyle,
+}
+
+export const getDefaultComponentsWithTheme = (
+  theme: PortableTextTheme,
+): PortableTextReactComponents => {
+  return {
+    types: {},
+
+    block: getDefaultBlockStylesWithTheme(theme),
+    marks: defaultMarks,
+    list: DefaultList,
+    listItem: getDefaultListItemsWithTheme(theme),
+    hardBreak: DefaultHardBreak,
+
+    unknownType: DefaultUnknownType,
+    unknownMark: DefaultUnknownMark,
+    unknownList: DefaultUnknownList,
+    unknownListItem: DefaultUnknownListItem,
+    unknownBlockStyle: DefaultUnknownBlockStyle,
+  }
 }

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -3,7 +3,7 @@ import {View, Text} from 'react-native'
 import type {PortableTextListComponent, PortableTextListItemComponent} from '@portabletext/react'
 import type {PortableTextListItemType} from '@portabletext/types'
 
-import {listStyles} from './styles'
+import {PortableTextTheme, getListStylesWithTheme, listStyles} from './styles'
 
 export const DefaultList: PortableTextListComponent = ({value, children}) => {
   const base = value.level > 1 ? listStyles.listDeep : listStyles.list
@@ -27,4 +27,30 @@ export const defaultListItems: Record<
       <Text style={listStyles.listItem}>{children}</Text>
     </View>
   ),
+}
+
+export const getDefaultListItemsWithTheme = (
+  theme: PortableTextTheme,
+): Record<PortableTextListItemType, PortableTextListItemComponent | undefined> => {
+  const listStylesWithTheme = getListStylesWithTheme(theme)
+
+  const defaultListItemsWithTheme: Record<
+    PortableTextListItemType,
+    PortableTextListItemComponent | undefined
+  > = {
+    bullet: ({children}) => (
+      <View style={listStylesWithTheme.listItemWrapper}>
+        <Text style={listStylesWithTheme.bulletListIcon}>{'\u00B7'}</Text>
+        <Text style={listStylesWithTheme.listItem}>{children}</Text>
+      </View>
+    ),
+    number: ({children, index}) => (
+      <View style={listStylesWithTheme.listItemWrapper}>
+        <Text style={listStylesWithTheme.bulletListIcon}>{index + 1}. </Text>
+        <Text style={listStylesWithTheme.listItem}>{children}</Text>
+      </View>
+    ),
+  }
+
+  return defaultListItemsWithTheme
 }

--- a/src/components/styles.ts
+++ b/src/components/styles.ts
@@ -1,5 +1,7 @@
 import {StyleSheet} from 'react-native'
 
+export type PortableTextTheme = {fontColor: string; fontFamily: string}
+
 export const blockStyles = StyleSheet.create({
   normal: {marginBottom: 16},
 
@@ -45,6 +47,38 @@ export const listStyles = StyleSheet.create({
   },
 })
 
+export const getListStylesWithTheme = (theme: PortableTextTheme): typeof listStyles =>
+  StyleSheet.create({
+    list: {
+      marginVertical: 16,
+    },
+
+    listDeep: {
+      marginVertical: 0,
+    },
+
+    listItem: {
+      flex: 1,
+      flexWrap: 'wrap',
+      flexDirection: 'row',
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+
+    bulletListIcon: {
+      marginLeft: 10,
+      marginRight: 10,
+      fontWeight: 'bold',
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+
+    listItemWrapper: {
+      flexDirection: 'row',
+      justifyContent: 'flex-start',
+    },
+  })
+
 export const textStyles = StyleSheet.create({
   h1: {
     fontWeight: 'bold',
@@ -79,6 +113,60 @@ export const textStyles = StyleSheet.create({
   normal: {},
   blockquote: {},
 })
+
+export const getTextStylesWithTheme = (theme: PortableTextTheme): typeof textStyles =>
+  StyleSheet.create({
+    h1: {
+      fontWeight: 'bold',
+      fontSize: 32,
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+
+    h2: {
+      fontWeight: 'bold',
+      fontSize: 24,
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+
+    h3: {
+      fontWeight: 'bold',
+      fontSize: 18,
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+
+    h4: {
+      fontWeight: 'bold',
+      fontSize: 16,
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+
+    h5: {
+      fontWeight: 'bold',
+      fontSize: 14,
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+
+    h6: {
+      fontWeight: 'bold',
+      fontSize: 10,
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+
+    normal: {
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+    blockquote: {
+      color: theme.fontColor,
+      fontFamily: theme.fontFamily,
+    },
+  })
 
 export const markStyles = StyleSheet.create({
   strong: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from '@portabletext/react'
 export {PortableText} from './react-native-portable-text'
 export {defaultComponents} from './components/defaults'
+export type {PortableTextTheme} from './components/styles'

--- a/src/react-native-portable-text.tsx
+++ b/src/react-native-portable-text.tsx
@@ -2,15 +2,14 @@ import React from 'react'
 import type {PortableTextProps} from '@portabletext/react'
 import type {TypedObject, PortableTextBlock} from '@portabletext/types'
 import {PortableText as BasePortableText, mergeComponents} from '@portabletext/react'
-import {defaultComponents} from './components/defaults'
+import {defaultComponents, getDefaultComponentsWithTheme} from './components/defaults'
+import {PortableTextTheme} from './components/styles'
 
 export function PortableText<B extends TypedObject = PortableTextBlock>(
-  props: Omit<PortableTextProps<B>, 'listNestingMode'>,
+  props: Omit<PortableTextProps<B>, 'listNestingMode'> & {theme?: PortableTextTheme},
 ) {
+  const components = props.theme ? getDefaultComponentsWithTheme(props.theme) : defaultComponents
   return (
-    <BasePortableText
-      {...props}
-      components={mergeComponents(defaultComponents, props.components ?? {})}
-    />
+    <BasePortableText {...props} components={mergeComponents(components, props.components ?? {})} />
   )
 }

--- a/test/__snapshots__/runthrough.test.tsx.snap
+++ b/test/__snapshots__/runthrough.test.tsx.snap
@@ -5539,3 +5539,6373 @@ exports[`never mutates input > styledListItems 1`] = `
   </View>,
 ]
 `;
+
+exports[`with theme > allBasicMarks 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "backgroundColor": "rgba(27, 31, 35, 0.05)",
+          "color": "#24292e",
+          "paddingHorizontal": 5,
+          "paddingVertical": 3,
+        }
+      }
+    >
+      code
+    </Text>
+    <Text
+      style={
+        {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      strong
+    </Text>
+    <Text
+      style={
+        {
+          "fontStyle": "italic",
+        }
+      }
+    >
+      em
+    </Text>
+    <Text
+      style={
+        {
+          "textDecorationLine": "underline",
+        }
+      }
+    >
+      underline
+    </Text>
+    <Text
+      style={
+        {
+          "textDecorationLine": "line-through",
+        }
+      }
+    >
+      strike-through
+    </Text>
+    <Text
+      onPress={[Function]}
+      style={
+        {
+          "textDecorationLine": "underline",
+        }
+      }
+    >
+      link
+    </Text>
+  </Text>
+</View>
+`;
+
+exports[`with theme > allDefaultBlockStyles 1`] = `
+[
+  <View
+    style={
+      {
+        "marginVertical": 22,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 32,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Sanity
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      The outline
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      More narrow details
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 16,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Even less thing
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 14,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Small header
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 10,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lowest thing
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "borderLeftColor": "#dfe2e5",
+        "borderLeftWidth": 3.5,
+        "marginBottom": 16,
+        "paddingHorizontal": 14,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      A block quote of awesomeness
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Plain old normal block
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Default to "normal" style
+    </Text>
+  </View>,
+]
+`;
+
+exports[`with theme > basicBulletList 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Let's test some of these lists!
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Bullet 1
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Bullet 2
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Bullet 3
+      </Text>
+    </View>
+  </View>,
+]
+`;
+
+exports[`with theme > basicMarkMultipleAdjacentSpans 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      A word of
+       warning;
+    </Text>
+     Sanity is addictive.
+  </Text>
+</View>
+`;
+
+exports[`with theme > basicMarkNestedMarks 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "fontWeight": "bold",
+        }
+      }
+    >
+      A word of 
+      <Text
+        style={
+          {
+            "fontStyle": "italic",
+          }
+        }
+      >
+        warning;
+      </Text>
+    </Text>
+     Sanity is addictive.
+  </Text>
+</View>
+`;
+
+exports[`with theme > basicMarkSingleSpan 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "backgroundColor": "rgba(27, 31, 35, 0.05)",
+          "color": "#24292e",
+          "paddingHorizontal": 5,
+          "paddingVertical": 3,
+        }
+      }
+    >
+      sanity
+    </Text>
+     is the name of the CLI tool.
+  </Text>
+</View>
+`;
+
+exports[`with theme > basicNumberedList 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Let's test some of these lists!
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        1
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Number 1
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        2
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Number 2
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        3
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Number 3
+      </Text>
+    </View>
+  </View>,
+]
+`;
+
+exports[`with theme > customBlockType 1`] = `
+<Text
+  style={
+    {
+      "display": "none",
+    }
+  }
+>
+  Unknown block type "code", specify a component for it in the \`components.types\` prop
+</Text>
+`;
+
+exports[`with theme > customListItemType 1`] = `
+<View
+  style={
+    [
+      {
+        "marginVertical": 16,
+      },
+      {
+        "paddingLeft": 16,
+      },
+    ]
+  }
+>
+  <View
+    style={
+      {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "fontWeight": "bold",
+          "marginLeft": 10,
+          "marginRight": 10,
+        }
+      }
+    >
+      ·
+    </Text>
+    <Text
+      style={
+        {
+          "flex": 1,
+          "flexDirection": "row",
+          "flexWrap": "wrap",
+        }
+      }
+    >
+      Square 1
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "fontWeight": "bold",
+          "marginLeft": 10,
+          "marginRight": 10,
+        }
+      }
+    >
+      ·
+    </Text>
+    <Text
+      style={
+        {
+          "flex": 1,
+          "flexDirection": "row",
+          "flexWrap": "wrap",
+        }
+      }
+    >
+      Square 2
+      <View
+        style={
+          [
+            {
+              "marginVertical": 0,
+            },
+            {
+              "paddingLeft": 32,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            {
+              "flexDirection": "row",
+              "justifyContent": "flex-start",
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "fontWeight": "bold",
+                "marginLeft": 10,
+                "marginRight": 10,
+              }
+            }
+          >
+            ·
+          </Text>
+          <Text
+            style={
+              {
+                "flex": 1,
+                "flexDirection": "row",
+                "flexWrap": "wrap",
+              }
+            }
+          >
+            Dat disc
+          </Text>
+        </View>
+      </View>
+    </Text>
+  </View>
+  <View
+    style={
+      {
+        "flexDirection": "row",
+        "justifyContent": "flex-start",
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "fontWeight": "bold",
+          "marginLeft": 10,
+          "marginRight": 10,
+        }
+      }
+    >
+      ·
+    </Text>
+    <Text
+      style={
+        {
+          "flex": 1,
+          "flexDirection": "row",
+          "flexWrap": "wrap",
+        }
+      }
+    >
+      Square 3
+    </Text>
+  </View>
+</View>
+`;
+
+exports[`with theme > customMarks 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    <Text>
+      Sanity
+    </Text>
+  </Text>
+</View>
+`;
+
+exports[`with theme > deepWeirdLists 1`] = `
+[
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item a
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item b
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        1
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item 1
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        2
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item 2
+        <View
+          style={
+            [
+              {
+                "marginVertical": 0,
+              },
+              {
+                "paddingLeft": 32,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              1
+              . 
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Item 2, a
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              2
+              . 
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Item 2, b
+            </Text>
+          </View>
+        </View>
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        3
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item 3
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    />
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        In
+        <View
+          style={
+            [
+              {
+                "marginVertical": 0,
+              },
+              {
+                "paddingLeft": 32,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Out
+            </Text>
+          </View>
+        </View>
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        In
+        <View
+          style={
+            [
+              {
+                "marginVertical": 0,
+              },
+              {
+                "paddingLeft": 32,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Out
+              <View
+                style={
+                  [
+                    {
+                      "marginVertical": 0,
+                    },
+                    {
+                      "paddingLeft": 48,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flexDirection": "row",
+                      "justifyContent": "flex-start",
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      {
+                        "color": "white",
+                        "fontFamily": "Arial",
+                        "fontWeight": "bold",
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                      }
+                    }
+                  >
+                    ·
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "white",
+                        "flex": 1,
+                        "flexDirection": "row",
+                        "flexWrap": "wrap",
+                        "fontFamily": "Arial",
+                      }
+                    }
+                  >
+                    Even More
+                    <View
+                      style={
+                        [
+                          {
+                            "marginVertical": 0,
+                          },
+                          {
+                            "paddingLeft": 64,
+                          },
+                        ]
+                      }
+                    >
+                      <View
+                        style={
+                          {
+                            "flexDirection": "row",
+                            "justifyContent": "flex-start",
+                          }
+                        }
+                      >
+                        <Text
+                          style={
+                            {
+                              "color": "white",
+                              "fontFamily": "Arial",
+                              "fontWeight": "bold",
+                              "marginLeft": 10,
+                              "marginRight": 10,
+                            }
+                          }
+                        >
+                          ·
+                        </Text>
+                        <Text
+                          style={
+                            {
+                              "color": "white",
+                              "flex": 1,
+                              "flexDirection": "row",
+                              "flexWrap": "wrap",
+                              "fontFamily": "Arial",
+                            }
+                          }
+                        >
+                          Even deeper
+                        </Text>
+                      </View>
+                    </View>
+                  </Text>
+                </View>
+              </View>
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Two steps back
+            </Text>
+          </View>
+        </View>
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        All the way back
+        <View
+          style={
+            [
+              {
+                "marginVertical": 0,
+              },
+              {
+                "paddingLeft": 48,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Skip a step
+            </Text>
+          </View>
+        </View>
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        1
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        New list
+        <View
+          style={
+            [
+              {
+                "marginVertical": 0,
+              },
+              {
+                "paddingLeft": 32,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              1
+              . 
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Next level
+            </Text>
+          </View>
+        </View>
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        New bullet list
+      </Text>
+    </View>
+  </View>,
+]
+`;
+
+exports[`with theme > emptyArray 1`] = `null`;
+
+exports[`with theme > emptyBlock 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  />
+</View>
+`;
+
+exports[`with theme > hardBreaks 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    A paragraph
+    <Text>
+      
+
+    </Text>
+    can have hard
+    <Text>
+      
+
+    </Text>
+    <Text>
+      
+
+    </Text>
+    breaks.
+  </Text>
+</View>
+`;
+
+exports[`with theme > imageSupport 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Also, images are pretty common.
+    </Text>
+  </View>,
+  <Text
+    style={
+      {
+        "display": "none",
+      }
+    }
+  >
+    Unknown block type "image", specify a component for it in the \`components.types\` prop
+  </Text>,
+]
+`;
+
+exports[`with theme > imageWithHotspot 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Also, images are pretty common.
+    </Text>
+  </View>,
+  <Text
+    style={
+      {
+        "display": "none",
+      }
+    }
+  >
+    Unknown block type "image", specify a component for it in the \`components.types\` prop
+  </Text>,
+]
+`;
+
+exports[`with theme > inlineBlockWithText 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    Men, 
+    <Text
+      style={
+        {
+          "display": "none",
+        }
+      }
+    >
+      Unknown block type "button", specify a component for it in the \`components.types\` prop
+    </Text>
+    , da!
+  </Text>
+</View>
+`;
+
+exports[`with theme > inlineImages 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "backgroundColor": "rgba(27, 31, 35, 0.05)",
+            "color": "#24292e",
+            "paddingHorizontal": 5,
+            "paddingVertical": 3,
+          }
+        }
+      >
+        Foo! Bar!
+      </Text>
+      <Text
+        style={
+          {
+            "display": "none",
+          }
+        }
+      >
+        Unknown block type "image", specify a component for it in the \`components.types\` prop
+      </Text>
+      Neat
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "backgroundColor": "rgba(27, 31, 35, 0.05)",
+            "color": "#24292e",
+            "paddingHorizontal": 5,
+            "paddingVertical": 3,
+          }
+        }
+      >
+        Foo! Bar! 
+      </Text>
+      <Text
+        style={
+          {
+            "display": "none",
+          }
+        }
+      >
+        Unknown block type "image", specify a component for it in the \`components.types\` prop
+      </Text>
+      <Text
+        style={
+          {
+            "backgroundColor": "rgba(27, 31, 35, 0.05)",
+            "color": "#24292e",
+            "paddingHorizontal": 5,
+            "paddingVertical": 3,
+          }
+        }
+      >
+         Baz!
+      </Text>
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Foo! Bar! 
+      <Text
+        style={
+          {
+            "display": "none",
+          }
+        }
+      >
+        Unknown block type "image", specify a component for it in the \`components.types\` prop
+      </Text>
+      <Text
+        style={
+          {
+            "backgroundColor": "rgba(27, 31, 35, 0.05)",
+            "color": "#24292e",
+            "paddingHorizontal": 5,
+            "paddingVertical": 3,
+          }
+        }
+      >
+         Baz!
+      </Text>
+    </Text>
+  </View>,
+]
+`;
+
+exports[`with theme > inlineNodes 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      I enjoyed it. It's not perfect, but I give it a strong 
+      <Text
+        style={
+          {
+            "display": "none",
+          }
+        }
+      >
+        Unknown block type "rating", specify a component for it in the \`components.types\` prop
+      </Text>
+      , and look forward to the next season!
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Sibling paragraph
+    </Text>
+  </View>,
+]
+`;
+
+exports[`with theme > keyless 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      sanity
+       is a full time job
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      in a world that 
+      is always changing
+    </Text>
+  </View>,
+]
+`;
+
+exports[`with theme > linkMarkDef 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    A word of warning; 
+    <Text
+      onPress={[Function]}
+      style={
+        {
+          "textDecorationLine": "underline",
+        }
+      }
+    >
+      Sanity
+    </Text>
+     is addictive.
+  </Text>
+</View>
+`;
+
+exports[`with theme > listIssue 1`] = `
+[
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        1
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        2
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        3
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        4
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        5
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        6
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        7
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        8
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        9
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        10
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+      <Text
+        onPress={[Function]}
+        style={
+          {
+            "textDecorationLine": "underline",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+      Lorem ipsum
+      <Text
+        onPress={[Function]}
+        style={
+          {
+            "textDecorationLine": "underline",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+      Lorem ipsum
+      <Text
+        onPress={[Function]}
+        style={
+          {
+            "textDecorationLine": "underline",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <Text
+          style={
+            {
+              "fontStyle": "italic",
+            }
+          }
+        >
+          Lorem ipsum
+        </Text>
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 18,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 18,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <View
+          style={
+            [
+              {
+                "marginVertical": 0,
+              },
+              {
+                "paddingLeft": 32,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+        </View>
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <View
+          style={
+            [
+              {
+                "marginVertical": 0,
+              },
+              {
+                "paddingLeft": 32,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              ·
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Lorem ipsum
+            </Text>
+          </View>
+        </View>
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+      <Text
+        style={
+          {
+            "fontStyle": "italic",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        1
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        2
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        3
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        4
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        5
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <Text
+          onPress={[Function]}
+          style={
+            {
+              "textDecorationLine": "underline",
+            }
+          }
+        >
+          Lorem ipsum
+        </Text>
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <Text
+          onPress={[Function]}
+          style={
+            {
+              "textDecorationLine": "underline",
+            }
+          }
+        >
+          Lorem ipsum
+        </Text>
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <Text
+          onPress={[Function]}
+          style={
+            {
+              "textDecorationLine": "underline",
+            }
+          }
+        >
+          Lorem ipsum
+        </Text>
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <Text
+          onPress={[Function]}
+          style={
+            {
+              "textDecorationLine": "underline",
+            }
+          }
+        >
+          Lorem ipsum
+        </Text>
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <Text
+          onPress={[Function]}
+          style={
+            {
+              "textDecorationLine": "underline",
+            }
+          }
+        >
+          Lorem ipsum
+        </Text>
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <Text
+          onPress={[Function]}
+          style={
+            {
+              "textDecorationLine": "underline",
+            }
+          }
+        >
+          Lorem ipsum
+        </Text>
+        Lorem ipsum
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Lorem ipsum
+        <Text
+          onPress={[Function]}
+          style={
+            {
+              "textDecorationLine": "underline",
+            }
+          }
+        >
+          Lorem ipsum
+        </Text>
+        Lorem ipsum
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Lorem ipsum
+    </Text>
+  </View>,
+]
+`;
+
+exports[`with theme > listWithoutLevel 1`] = `
+[
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      In-person access: Research appointments
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      The collection may be examined by arranging a research appointment 
+      <Text
+        style={
+          {
+            "fontWeight": "bold",
+          }
+        }
+      >
+        in advance
+      </Text>
+       by contacting the ACT archivist by email or phone. ACT generally does not accept walk-in research patrons, although requests may be made in person at the Archivist’s office (E15-222). ACT recommends arranging appointments at least three weeks in advance in order to ensure availability. ACT reserves the right to cancel research appointments at any time. Appointment scheduling is subject to institute holidays and closings. 
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      The collection space is located at:
+      <Text>
+        
+
+      </Text>
+      20 Ames Street
+      <Text>
+        
+
+      </Text>
+      Building E15-235
+      <Text>
+        
+
+      </Text>
+      Cambridge, Massachusetts 02139
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      In-person access: Space policies
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        The Archivist or an authorized ACT staff member must attend researchers at all times.
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        No pens, markers, or adhesives (e.g. “Post-it” notes) are permitted in the collection space; pencils will be provided upon request.
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Cotton gloves must be worn when handling collection materials; gloves will be provided by the Archivist.
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        No food or beverages are permitted in the collection space.
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Laptop use is permitted in the collection space, as well as digital cameras and cellphones. Unless otherwise authorized, any equipment in the collection space (including but not limited to computers, telephones, scanners, and viewing equipment) is for use by ACT staff members only.
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Photocopying machines in the ACT hallway will be accessible by patrons under the supervision of the Archivist.
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Patrons may only browse materials that have been made available for access.
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      Remote access: Reference requests
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      For patrons who are unable to arrange for an on-campus visit to the Archives and Special Collections, reference questions may be directed to the Archivist remotely by email or phone. Generally, emails and phone calls will receive a response within 72 hours of receipt. Requests are typically filled in the order they are received.
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "fontWeight": "bold",
+          }
+        }
+      >
+        Use of patron information
+      </Text>
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Patrons requesting collection materials in person or remotely may be asked to provide certain information to the Archivist, such as contact information and topic(s) of research. This information is only used to track requests for statistical evaluations of collection use and will not be disclosed to outside organizations for any purpose. ACT will endeavor to protect the privacy of all patrons accessing collections.
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "fontWeight": "bold",
+          }
+        }
+      >
+        Fees
+      </Text>
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      ACT reserves the right to charge an hourly rate for requests that require more than three hours of research on behalf of a patron (remote requests). Collection materials may be scanned and made available upon request, but digitization of certain materials may incur costs. Additionally, requests to publish, exhibit, or otherwise reproduce and display collection materials may incur use fees.
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginVertical": 20,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+          "fontSize": 24,
+          "fontWeight": "bold",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "fontWeight": "bold",
+          }
+        }
+      >
+        Use of MIT-owned materials by patrons
+      </Text>
+    </Text>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Permission to examine collection materials in person or remotely (by receiving transfers of digitized materials) does not imply or grant permission to publish or exhibit those materials. Permission to publish, exhibit, or otherwise use collection materials is granted on a case by case basis in accordance with MIT policy, restrictions that may have been placed on materials by donors or depositors, and copyright law. To request permission to publish, exhibit, or otherwise use collection materials, contact the Archivist. 
+      <Text
+        style={
+          {
+            "fontWeight": "bold",
+          }
+        }
+      >
+        When permission is granted by MIT, patrons must comply with all guidelines provided by ACT for citations, credits, and copyright statements. Exclusive rights to examine or publish material will not be granted.
+      </Text>
+    </Text>
+  </View>,
+]
+`;
+
+exports[`with theme > marksAllTheWayDown 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    <Text>
+      <Text>
+        <Text
+          style={
+            {
+              "fontStyle": "italic",
+            }
+          }
+        >
+          Sanity
+           FTW
+        </Text>
+      </Text>
+    </Text>
+  </Text>
+</View>
+`;
+
+exports[`with theme > materializedImageSupport 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Also, images are pretty common.
+    </Text>
+  </View>,
+  <Text
+    style={
+      {
+        "display": "none",
+      }
+    }
+  >
+    Unknown block type "image", specify a component for it in the \`components.types\` prop
+  </Text>,
+]
+`;
+
+exports[`with theme > messyLinkText 1`] = `
+<View
+  style={
+    {
+      "borderLeftColor": "#dfe2e5",
+      "borderLeftWidth": 3.5,
+      "marginBottom": 16,
+      "paddingHorizontal": 14,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    <Text
+      onPress={[Function]}
+      style={
+        {
+          "textDecorationLine": "underline",
+        }
+      }
+    >
+      Sanity
+    </Text>
+     can be used to power almost any 
+    <Text
+      onPress={[Function]}
+      style={
+        {
+          "textDecorationLine": "underline",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "fontStyle": "italic",
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          app
+        </Text>
+         or website
+      </Text>
+    </Text>
+    .
+  </Text>
+</View>
+`;
+
+exports[`with theme > missingMarkComponent 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    <Text>
+      A word of 
+      <Text
+        style={
+          {
+            "fontStyle": "italic",
+          }
+        }
+      >
+        warning;
+      </Text>
+    </Text>
+     Sanity is addictive.
+  </Text>
+</View>
+`;
+
+exports[`with theme > multipleSpans 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    Span number one. 
+    And span number two.
+  </Text>
+</View>
+`;
+
+exports[`with theme > nestedLists 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Span
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item 1, level 1
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item 2, level 1
+        <View
+          style={
+            [
+              {
+                "marginVertical": 0,
+              },
+              {
+                "paddingLeft": 32,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              1
+              . 
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Item 3, level 2
+              <View
+                style={
+                  [
+                    {
+                      "marginVertical": 0,
+                    },
+                    {
+                      "paddingLeft": 48,
+                    },
+                  ]
+                }
+              >
+                <View
+                  style={
+                    {
+                      "flexDirection": "row",
+                      "justifyContent": "flex-start",
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      {
+                        "color": "white",
+                        "fontFamily": "Arial",
+                        "fontWeight": "bold",
+                        "marginLeft": 10,
+                        "marginRight": 10,
+                      }
+                    }
+                  >
+                    1
+                    . 
+                  </Text>
+                  <Text
+                    style={
+                      {
+                        "color": "white",
+                        "flex": 1,
+                        "flexDirection": "row",
+                        "flexWrap": "wrap",
+                        "fontFamily": "Arial",
+                      }
+                    }
+                  >
+                    Item 4, level 3
+                  </Text>
+                </View>
+              </View>
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              2
+              . 
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Item 5, level 2
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              3
+              . 
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Item 6, level 2
+            </Text>
+          </View>
+        </View>
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item 7, level 1
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item 8, level 1
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        1
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item 1 of list 2
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        2
+        . 
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Item 2 of list 2
+        <View
+          style={
+            [
+              {
+                "marginVertical": 0,
+              },
+              {
+                "paddingLeft": 32,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "row",
+                "justifyContent": "flex-start",
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "fontFamily": "Arial",
+                  "fontWeight": "bold",
+                  "marginLeft": 10,
+                  "marginRight": 10,
+                }
+              }
+            >
+              1
+              . 
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "white",
+                  "flex": 1,
+                  "flexDirection": "row",
+                  "flexWrap": "wrap",
+                  "fontFamily": "Arial",
+                }
+              }
+            >
+              Item 3 of list 2, level 2
+            </Text>
+          </View>
+        </View>
+      </Text>
+    </View>
+  </View>,
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Just a block
+    </Text>
+  </View>,
+]
+`;
+
+exports[`with theme > overrideDefaultMarks 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    <Text
+      onPress={[Function]}
+      style={
+        {
+          "textDecorationLine": "underline",
+        }
+      }
+    >
+      Sanity
+    </Text>
+  </Text>
+</View>
+`;
+
+exports[`with theme > overrideDefaults 1`] = `
+<Text
+  style={
+    {
+      "display": "none",
+    }
+  }
+>
+  Unknown block type "image", specify a component for it in the \`components.types\` prop
+</Text>
+`;
+
+exports[`with theme > plainHeaderBlock 1`] = `
+<View
+  style={
+    {
+      "marginVertical": 20,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+        "fontSize": 24,
+        "fontWeight": "bold",
+      }
+    }
+  >
+    Dat heading
+  </Text>
+</View>
+`;
+
+exports[`with theme > singleSpan 1`] = `
+<View
+  style={
+    {
+      "marginBottom": 16,
+    }
+  }
+>
+  <Text
+    style={
+      {
+        "color": "white",
+        "fontFamily": "Arial",
+      }
+    }
+  >
+    Plain text.
+  </Text>
+</View>
+`;
+
+exports[`with theme > styledListItems 1`] = `
+[
+  <View
+    style={
+      {
+        "marginBottom": 16,
+      }
+    }
+  >
+    <Text
+      style={
+        {
+          "color": "white",
+          "fontFamily": "Arial",
+        }
+      }
+    >
+      Let's test some of these lists!
+    </Text>
+  </View>,
+  <View
+    style={
+      [
+        {
+          "marginVertical": 16,
+        },
+        {
+          "paddingLeft": 16,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Bullet 1
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "marginVertical": 22,
+            }
+          }
+        >
+          <Text
+            style={
+              {
+                "color": "white",
+                "fontFamily": "Arial",
+                "fontSize": 32,
+                "fontWeight": "bold",
+              }
+            }
+          >
+            Bullet 2
+          </Text>
+        </View>
+      </Text>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "row",
+          "justifyContent": "flex-start",
+        }
+      }
+    >
+      <Text
+        style={
+          {
+            "color": "white",
+            "fontFamily": "Arial",
+            "fontWeight": "bold",
+            "marginLeft": 10,
+            "marginRight": 10,
+          }
+        }
+      >
+        ·
+      </Text>
+      <Text
+        style={
+          {
+            "color": "white",
+            "flex": 1,
+            "flexDirection": "row",
+            "flexWrap": "wrap",
+            "fontFamily": "Arial",
+          }
+        }
+      >
+        Bullet 3
+      </Text>
+    </View>
+  </View>,
+]
+`;

--- a/test/runthrough.test.tsx
+++ b/test/runthrough.test.tsx
@@ -28,3 +28,19 @@ test('never mutates input', () => {
     expect(originalInput).toMatchObject(passedInput)
   }
 })
+
+test('with theme', () => {
+  for (const [key, fixture] of Object.entries(fixtures)) {
+    if (key === 'default') {
+      continue
+    }
+
+    const tree = renderer
+      .create(
+        <PortableText value={fixture.input} theme={{fontColor: 'white', fontFamily: 'Arial'}} />,
+      )
+      .toJSON()
+
+    expect(tree).toMatchSnapshot(key)
+  }
+})


### PR DESCRIPTION
Context:
> My app is using a dark theme, the text by default is black, having the possibility to set a default font theme instead of rewriting default components would be nice

Solution:
> Added a new props called `theme` which can take `fontColor` and `fontFamily` props
```jsx
 <PortableText value={value} theme={{fontColor: 'white', fontFamily: 'Arial'}} />
```

PS: also fixed a typescript issue for locating types file due to `index.d.ts` file not being specified in `package.json`